### PR TITLE
Adding an "inc" command to the RpcHandler for autonomous increments.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,6 +69,7 @@ tsdb_SRC := \
 	src/tsd/LogsRpc.java	\
 	src/tsd/PipelineFactory.java	\
 	src/tsd/PutDataPointRpc.java	\
+	src/tsd/IncDataPointRpc.java	\
 	src/tsd/RpcHandler.java	\
 	src/tsd/StaticFileRpc.java	\
 	src/tsd/TelnetRpc.java	\

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -12,30 +12,20 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+import com.stumbleupon.async.DeferredGroupException;
+import net.opentsdb.stats.Histogram;
+import net.opentsdb.stats.StatsCollector;
+import net.opentsdb.uid.UniqueId;
+import org.hbase.async.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
-import com.stumbleupon.async.Callback;
-import com.stumbleupon.async.Deferred;
-import com.stumbleupon.async.DeferredGroupException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.hbase.async.Bytes;
-import org.hbase.async.ClientStats;
-import org.hbase.async.DeleteRequest;
-import org.hbase.async.GetRequest;
-import org.hbase.async.HBaseClient;
-import org.hbase.async.HBaseException;
-import org.hbase.async.KeyValue;
-import org.hbase.async.PutRequest;
-
-import net.opentsdb.uid.UniqueId;
-import net.opentsdb.stats.Histogram;
-import net.opentsdb.stats.StatsCollector;
 
 /**
  * Thread-safe implementation of the TSDB client.
@@ -297,12 +287,101 @@ public final class TSDB {
     scheduleForCompaction(row, (int) base_time);
     final short qualifier = (short) ((timestamp - base_time) << Const.FLAG_BITS
                                      | flags);
-    final PutRequest point = new PutRequest(table, row, FAMILY,
-                                            Bytes.fromShort(qualifier), value);
+    final PutRequest point = new PutRequest(table, row, FAMILY, Bytes.fromShort(qualifier), value);
     // TODO(tsuna): Add a callback to time the latency of HBase and store the
     // timing in a moving Histogram (once we have a class for this).
     return client.put(point);
   }
+
+
+    /**
+     * Increments a single integer value data point in the TSDB.
+     * @param metric A non-empty string.
+     * @param timestamp The timestamp associated with the value.
+     * @param value The value of the data point.
+     * @param tags The tags on this series.  This map must be non-empty.
+     * @return A deferred object that indicates the completion of the request.
+     * The {@link Object} has not special meaning and can be {@code null} (think
+     * of it as {@code Deferred<Void>}). But you probably want to attach at
+     * least an errback to this {@code Deferred} to handle failures.
+     * @throws IllegalArgumentException if the timestamp is less than or equal
+     * to the previous timestamp added or 0 for the first timestamp, or if the
+     * difference with the previous timestamp is too large.
+     * @throws IllegalArgumentException if the metric name is empty or contains
+     * illegal characters.
+     * @throws IllegalArgumentException if the tags list is empty or one of the
+     * elements contains illegal characters.
+     * @throws HBaseException (deferred) if there was a problem while persisting
+     * data.
+     */
+    public Deferred<Object> incPoint(final String metric,
+                                     final long timestamp,
+                                     final long value,
+                                     final Map<String, String> tags) {
+        final short flags = 0x7;  // An int stored on 8 bytes.
+        return incPointInternal(metric, timestamp, value, tags, flags);
+    }
+
+    /**
+     * Incrementsw a single floating-point value data point in the TSDB.
+     * @param metric A non-empty string.
+     * @param timestamp The timestamp associated with the value.
+     * @param value The value of the data point.
+     * @param tags The tags on this series.  This map must be non-empty.
+     * @return A deferred object that indicates the completion of the request.
+     * The {@link Object} has not special meaning and can be {@code null} (think
+     * of it as {@code Deferred<Void>}). But you probably want to attach at
+     * least an errback to this {@code Deferred} to handle failures.
+     * @throws IllegalArgumentException if the timestamp is less than or equal
+     * to the previous timestamp added or 0 for the first timestamp, or if the
+     * difference with the previous timestamp is too large.
+     * @throws IllegalArgumentException if the metric name is empty or contains
+     * illegal characters.
+     * @throws IllegalArgumentException if the value is NaN or infinite.
+     * @throws IllegalArgumentException if the tags list is empty or one of the
+     * elements contains illegal characters.
+     * @throws HBaseException (deferred) if there was a problem while persisting
+     * data.
+     */
+    public Deferred<Object> incPoint(final String metric,
+                                     final long timestamp,
+                                     final float value,
+                                     final Map<String, String> tags) {
+        if (Float.isNaN(value) || Float.isInfinite(value)) {
+            throw new IllegalArgumentException("value is NaN or Infinite: " + value
+                    + " for metric=" + metric
+                    + " timestamp=" + timestamp);
+        }
+        final short flags = Const.FLAG_FLOAT | 0x3;  // A float stored on 4 bytes.
+        return incPointInternal(metric, timestamp, Float.floatToRawIntBits(value), tags, flags);
+    }
+
+
+    private Deferred<Object> incPointInternal(final String metric,
+                                              final long timestamp,
+                                              final long value,
+                                              final Map<String, String> tags,
+                                              final short flags) {
+        if ((timestamp & 0xFFFFFFFF00000000L) != 0) {
+            // => timestamp < 0 || timestamp > Integer.MAX_VALUE
+            throw new IllegalArgumentException((timestamp < 0 ? "negative " : "bad")
+                    + " timestamp=" + timestamp
+                    + " when trying to add value=" + value + '/' + flags
+                    + " to metric=" + metric + ", tags=" + tags);
+        }
+
+        IncomingDataPoints.checkMetricAndTags(metric, tags);
+        final byte[] row = IncomingDataPoints.rowKeyTemplate(this, metric, tags);
+        final long base_time = (timestamp - (timestamp % Const.MAX_TIMESPAN));
+        Bytes.setInt(row, (int) base_time, metrics.width());
+        scheduleForCompaction(row, (int) base_time);
+        final short qualifier = (short) ((timestamp - base_time) << Const.FLAG_BITS
+                | flags);
+        final AtomicIncrementRequest point = new AtomicIncrementRequest(table, row, FAMILY, Bytes.fromShort(qualifier), value);
+        // TODO(tsuna): Add a callback to time the latency of HBase and store the
+        // timing in a moving Histogram (once we have a class for this).
+        return client.atomicIncrement(true, point);
+    }
 
   /**
    * Forces a flush of any un-committed in memory data.

--- a/src/tsd/IncDataPointRpc.java
+++ b/src/tsd/IncDataPointRpc.java
@@ -1,0 +1,122 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2012  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.tsd;
+
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.core.Tags;
+import net.opentsdb.stats.StatsCollector;
+import net.opentsdb.uid.NoSuchUniqueName;
+import org.jboss.netty.channel.Channel;
+
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Implements the "inc" telnet-style command. */
+final class IncDataPointRpc implements TelnetRpc {
+
+  private static final AtomicLong requests = new AtomicLong();
+  private static final AtomicLong hbase_errors = new AtomicLong();
+  private static final AtomicLong invalid_values = new AtomicLong();
+  private static final AtomicLong illegal_arguments = new AtomicLong();
+  private static final AtomicLong unknown_metrics = new AtomicLong();
+
+  public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
+                                  final String[] cmd) {
+    requests.incrementAndGet();
+    String errmsg = null;
+    try {
+      final class PutErrback implements Callback<Exception, Exception> {
+        public Exception call(final Exception arg) {
+          if (chan.isConnected()) {
+            chan.write("inc: HBase error: " + arg.getMessage() + '\n');
+          }
+          hbase_errors.incrementAndGet();
+          return arg;
+        }
+        public String toString() {
+          return "report error to channel";
+        }
+      }
+      return importDataPoint(tsdb, cmd).addErrback(new PutErrback());
+    } catch (NumberFormatException x) {
+      errmsg = "inc: invalid value: " + x.getMessage() + '\n';
+      invalid_values.incrementAndGet();
+    } catch (IllegalArgumentException x) {
+      errmsg = "inc: illegal argument: " + x.getMessage() + '\n';
+      illegal_arguments.incrementAndGet();
+    } catch (NoSuchUniqueName x) {
+      errmsg = "inc: unknown metric: " + x.getMessage() + '\n';
+      unknown_metrics.incrementAndGet();
+    }
+    if (errmsg != null && chan.isConnected()) {
+      chan.write(errmsg);
+    }
+    return Deferred.fromResult(null);
+  }
+
+  /**
+   * Collects the stats and metrics tracked by this instance.
+   * @param collector The collector to use.
+   */
+  public static void collectStats(final StatsCollector collector) {
+    collector.record("rpc.received", requests, "type=inc");
+    collector.record("rpc.errors", hbase_errors, "type=hbase_errors");
+    collector.record("rpc.errors", invalid_values, "type=invalid_values");
+    collector.record("rpc.errors", illegal_arguments, "type=illegal_arguments");
+    collector.record("rpc.errors", unknown_metrics, "type=unknown_metrics");
+  }
+
+  /**
+   * Increments a single data point.
+   * @param tsdb The TSDB to increment the data point into.
+   * @param words The words describing the data point to import, in
+   * the following format: {@code [metric, timestamp, value, ..tags..]}
+   * @return A deferred Long that indicates the completion of the request.
+   * @throws NumberFormatException if the timestamp or value is invalid.
+   * @throws IllegalArgumentException if any other argument is invalid.
+   * @throws net.opentsdb.uid.NoSuchUniqueName if the metric isn't registered.
+   */
+  private Deferred<Object> importDataPoint(final TSDB tsdb, final String[] words) {
+    words[0] = null; // Ditch the "inc".
+    if (words.length < 5) {  // Need at least: metric timestamp value tag
+      //               ^ 5 and not 4 because words[0] is "inc".
+      throw new IllegalArgumentException("not enough arguments"
+                                         + " (need least 4, got " + (words.length - 1) + ')');
+    }
+    final String metric = words[1];
+    if (metric.length() <= 0) {
+      throw new IllegalArgumentException("empty metric name");
+    }
+    final long timestamp = Tags.parseLong(words[2]);
+    if (timestamp <= 0) {
+      throw new IllegalArgumentException("invalid timestamp: " + timestamp);
+    }
+    final String value = words[3];
+    if (value.length() <= 0) {
+      throw new IllegalArgumentException("empty value");
+    }
+    final HashMap<String, String> tags = new HashMap<String, String>();
+    for (int i = 4; i < words.length; i++) {
+      if (!words[i].isEmpty()) {
+        Tags.parse(tags, words[i]);
+      }
+    }
+    if (value.indexOf('.') < 0) {  // integer value
+      return tsdb.incPoint(metric, timestamp, Tags.parseLong(value), tags);
+    } else {  // floating point value
+      return tsdb.incPoint(metric, timestamp, Float.parseFloat(value), tags);
+    }
+  }
+}

--- a/src/tsd/RpcHandler.java
+++ b/src/tsd/RpcHandler.java
@@ -12,28 +12,25 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.tsd;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
-
 import com.stumbleupon.async.Callback;
 import com.stumbleupon.async.Deferred;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import net.opentsdb.BuildData;
+import net.opentsdb.core.Aggregators;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.stats.StatsCollector;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
 import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import net.opentsdb.BuildData;
-import net.opentsdb.core.Aggregators;
-import net.opentsdb.core.TSDB;
-import net.opentsdb.stats.StatsCollector;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Stateless handler for RPCs (telnet-style or HTTP).
@@ -63,7 +60,7 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
   public RpcHandler(final TSDB tsdb) {
     this.tsdb = tsdb;
 
-    telnet_commands = new HashMap<String, TelnetRpc>(7);
+    telnet_commands = new HashMap<String, TelnetRpc>(8);
     http_commands = new HashMap<String, HttpRpc>(11);
     {
       final DieDieDie diediedie = new DieDieDie();
@@ -94,6 +91,7 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
     telnet_commands.put("exit", new Exit());
     telnet_commands.put("help", new Help());
     telnet_commands.put("put", new PutDataPointRpc());
+    telnet_commands.put("inc", new IncDataPointRpc());
 
     http_commands.put("", new HomePage());
     http_commands.put("aggregators", new ListAggregators());


### PR DESCRIPTION
Hi tsuna,
I've added an "inc" command to the RpcHandler for autonomous increments, based very heavily on the code for the "put" command.  It requires a slight modification to asynchbase to support Deffered<Object> returns from the HBaseClient.atomicIncrement() calls.  

I added an override to HBaseClient to support those and I will submit a pull request for that change as well.  The atomicIncrement override is a bit sloppy (just added a boolen value to the method signature) but it works, maybe a different method name would be more elegant? 

Either way, the code change has been running under fairly heavy load on our live environment and is working very well.
